### PR TITLE
Re-factor to handle stranger indentations

### DIFF
--- a/lib/unindent.js
+++ b/lib/unindent.js
@@ -51,7 +51,7 @@ function unindent(code, opts) {
 			}
 
 			if (opts.tabSize) {
-				line = line.replace(/^\t+/, function (tabs) {
+				line = line.replace(/^\s+/, function (tabs) {
 					var spaces = new Array(opts.tabSize + 1).join(' ');
 					return tabs.replace(/\t/g, spaces);
 				});

--- a/lib/unindent.js
+++ b/lib/unindent.js
@@ -26,18 +26,25 @@ function unindent(code, opts) {
 				}
 				current.count = current.indent.length;
 
-				if (opts.tabSize) {
-					var tabs = current.indent.split("\t").length - 1;
-					current.count = current.count + tabs * (opts.tabSize - 1);
-				}
-
-				if (!overall || current.count < overall.count) {
+				if (opts.simple) {
 					overall = current;
-					if (i > 0) {
-						debug('Re-calulating indentation (@%d): %o', i, overall)
-						return $$();
+					tested = lines.length;
+					debug('Indentation: %o', overall)
+
+				} else {
+					if (opts.tabSize) {
+						var tabs = current.indent.split("\t").length - 1;
+						current.count = current.count + tabs * (opts.tabSize - 1);
 					}
-					debug('Initial indentation: %o', overall)
+
+					if (!overall || current.count < overall.count) {
+						overall = current;
+						if (i > 0) {
+							debug('Re-calulating indentation (@%d): %o', i, overall)
+							return $$();
+						}
+						debug('Initial indentation: %o', overall)
+					}
 				}
 			}
 

--- a/lib/unindent.js
+++ b/lib/unindent.js
@@ -1,41 +1,65 @@
+try {       var debug = require('debug')('unindent'); }
+catch (_) {	var debug = function noop(){}; }
+
+
 module.exports = unindent;
 
 function unindent(code, opts) {
 	if (!opts) opts = {};
 
-	var indent;
-	var lines = code.split(/\r\n|[\r\n]/);
-	for (var i = 0, len = lines.length; i < len; ++i) {
-		var line = lines[i];
+	var overall;
+	var tested = -1;
+	var code = code.split(/\r\n|[\r\n]/);
+	var lines;
+	(function $$(){
+		lines = code.slice();
 
-		if (!line) continue;
+		for (var i = 0, len = lines.length; i < len; ++i) {
+			var line = lines[i];
 
-		if (!indent) {
-			indent = /^\s+/.exec(line);
-			// first non empty line has no indent
-			// no need to unindent rest lines
-			if (!indent) break;
-			indent = indent[0];
+			if (!line) continue;
+
+			if (i > tested) {
+				tested = i;
+				var current = {
+					indent: /^\s+|^/.exec(line)[0],
+				}
+				current.count = current.indent.length;
+
+				if (opts.tabSize) {
+					var tabs = current.indent.split("\t").length - 1;
+					current.count = current.count + tabs * (opts.tabSize - 1);
+				}
+
+				if (!overall || current.count < overall.count) {
+					overall = current;
+					if (i > 0) {
+						debug('Re-calulating indentation (@%d): %o', i, overall)
+						return $$();
+					}
+					debug('Initial indentation: %o', overall)
+				}
+			}
+
+			if (opts.trim && /^\s+$/.test(line)) {
+				lines[i] = '';
+				continue;
+			}
+
+			if (line.substr(0, overall.indent.length) === overall.indent) {
+				line = line.substr(overall.indent.length);
+			}
+
+			if (opts.tabSize) {
+				line = line.replace(/^\t+/, function (tabs) {
+					var spaces = new Array(opts.tabSize + 1).join(' ');
+					return tabs.replace(/\t/g, spaces);
+				});
+			}
+
+			lines[i] = line;
 		}
-
-		if (opts.trim && /^\s+$/.test(line)) {
-			lines[i] = '';
-			continue;
-		}
-
-		if (line.substr(0, indent.length) === indent) {
-			line = line.substr(indent.length);
-		}
-
-		if (opts.tabSize) {
-			line = line.replace(/^\t+/, function (tabs) {
-				var spaces = new Array(opts.tabSize + 1).join(' ');
-				return tabs.replace(/\t/g, spaces);
-			});
-		}
-
-		lines[i] = line;
-	}
+	})()
 
 	code = lines.join('\n');
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "debug": "~2.1",
-    "mocha": "1.x"
+    "mocha": "~2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/curvedmark/unindent/issues"
   },
   "devDependencies": {
+    "debug": "~2.1",
     "mocha": "1.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unindent",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Remove indentations from a block of code",
   "main": "lib/unindent.js",
   "directories": {
@@ -16,6 +16,9 @@
   },
   "keywords": [],
   "author": "Glen Huang <curvedmark@gmail.com>",
+  "contributors": [
+    "ELLIOTTCABLE (http://ell.io/tt)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/curvedmark/unindent/issues"

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,22 @@ it("should unindent space-indented code", function () {
 	assert.equal(unindent(code), unindented);
 });
 
+it("should unindent to the level of the shallowest line", function () {
+	var code = [
+		'		a',
+		'	b',
+		'	  c'
+	].join('\n');
+	var unindented = [
+		'	a',
+		'b',
+		'  c'
+	].join('\n');
+
+	assert.equal(unindent(code), unindented);
+});
+
+
 it("should be able to convert leading tabs in code", function () {
 	var code = [
 		'	a',

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,21 @@ it("should unindent to the level of the shallowest line", function () {
 	assert.equal(unindent(code), unindented);
 });
 
+it("should provide an option to use only the first line's indentation", function () {
+	var code = [
+		'		a',
+		'	b',
+		'		  c'
+	].join('\n');
+	var unindented = [
+		'a',
+		'	b',
+		'  c'
+	].join('\n');
+
+	assert.equal(unindent(code, { simple: true }), unindented);
+});
+
 
 it("should be able to convert leading tabs in code", function () {
 	var code = [

--- a/test/test.js
+++ b/test/test.js
@@ -31,7 +31,7 @@ it("should unindent space-indented code", function () {
 	assert.equal(unindent(code), unindented);
 });
 
-it("should be able to convert tabs in code", function () {
+it("should be able to convert leading tabs in code", function () {
 	var code = [
 		'	a',
 		'		b',
@@ -40,6 +40,21 @@ it("should be able to convert tabs in code", function () {
 	var unindented = [
 		'a',
 		'    b',
+		'  c'
+	].join('\n');
+
+	assert.equal(unindent(code, { tabSize: 4 }), unindented);
+});
+
+it("should ignore tabs mid-line when converting", function () {
+	var code = [
+		'	a',
+		'		b	',
+		'	  c'
+	].join('\n');
+	var unindented = [
+		'a',
+		'    b	',
 		'  c'
 	].join('\n');
 


### PR DESCRIPTION
I re-wrote much of the iteration code to restart and recurse if a line with _less_ indentation was found, effectively searching the document for the least-indented line.

I've retained the old approach for possible performance concerns; if a user prefers a naïve first-line-only approach, they can pass `{ simple: true }`.

Additionally, all of the above functionality is tested! (=

Let me know if you have any stylistic concerns or comments.
